### PR TITLE
Add profile page with avatar upload and migration

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,3 +71,13 @@ Yes, you can!
 To connect a domain, navigate to Project > Settings > Domains and click Connect Domain.
 
 Read more here: [Setting up a custom domain](https://docs.lovable.dev/tips-tricks/custom-domain#step-by-step-guide)
+
+## Database migrations
+
+To apply the latest database changes, run the SQL file in `supabase/migrations/20250908000000_profile_images.sql` on your Supabase instance.
+
+```sh
+psql $SUPABASE_DB_URL -f supabase/migrations/20250908000000_profile_images.sql
+```
+
+Run this SQL after pulling the repository to ensure your database schema is up to date.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -17,6 +17,7 @@ import Wishlist from "./pages/Wishlist";
 import Privacy from "./pages/Privacy";
 import Cookies from "./pages/Cookies";
 import Terms from "./pages/Terms";
+import Profile from "./pages/Profile";
 import { Footer } from "@/components/Footer";
 
 const queryClient = new QueryClient();
@@ -39,6 +40,7 @@ const App = () => (
               <Route path="/join/:token" element={<EventJoin />} />
               <Route path="/ideas" element={<Ideas />} />
               <Route path="/wishlist" element={<Wishlist />} />
+              <Route path="/profile" element={<Profile />} />
               <Route path="/privacy" element={<Privacy />} />
               <Route path="/cookies" element={<Cookies />} />
               <Route path="/terms" element={<Terms />} />

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -1,7 +1,9 @@
 import { Link, useLocation, useNavigate } from "react-router-dom";
+import { useEffect, useState } from "react";
 import { Button } from "@/components/ui/button";
 import { supabase } from "@/integrations/supabase/client";
 import { useAuth } from "@/components/AuthProvider";
+import { Avatar, AvatarImage, AvatarFallback } from "@/components/ui/avatar";
 import { Gift, Calendar, Lightbulb, User, LogOut, Heart } from "lucide-react";
 import { toast } from "sonner";
 
@@ -9,6 +11,20 @@ export const Navbar = () => {
   const { user, loading } = useAuth();
   const location = useLocation();
   const navigate = useNavigate();
+  const [avatarUrl, setAvatarUrl] = useState<string | null>(null);
+
+  useEffect(() => {
+    async function load() {
+      if (!user) return;
+      const { data } = await supabase
+        .from("profiles")
+        .select("avatar_url")
+        .eq("id", user.id)
+        .single();
+      setAvatarUrl(data?.avatar_url ?? null);
+    }
+    load();
+  }, [user]);
 
   const handleLogout = async () => {
     try {
@@ -101,10 +117,14 @@ export const Navbar = () => {
         </div>
 
         <div className="flex items-center gap-2">
-          <Button variant="ghost" size="sm" className="hidden md:flex">
-            <User className="w-4 h-4 mr-2" />
-            Profilo
-          </Button>
+          <Link to="/profile" className="hidden md:flex">
+            <Avatar className="w-8 h-8">
+              <AvatarImage src={avatarUrl || undefined} />
+              <AvatarFallback>
+                <User className="w-4 h-4" />
+              </AvatarFallback>
+            </Avatar>
+          </Link>
           <Button 
             variant="outline" 
             size="sm" 
@@ -152,14 +172,18 @@ export const Navbar = () => {
             <Heart className="w-4 h-4" />
             <span className="text-xs">Lista</span>
           </Link>
-          <Button 
-            variant="ghost" 
-            size="sm" 
+          <Link
+            to="/profile"
             className="flex flex-col items-center gap-1 px-3 py-2 h-auto text-muted-foreground"
           >
-            <User className="w-4 h-4" />
+            <Avatar className="w-6 h-6">
+              <AvatarImage src={avatarUrl || undefined} />
+              <AvatarFallback>
+                <User className="w-4 h-4" />
+              </AvatarFallback>
+            </Avatar>
             <span className="text-xs">Profilo</span>
-          </Button>
+          </Link>
         </div>
       </div>
     </nav>

--- a/src/integrations/supabase/types.ts
+++ b/src/integrations/supabase/types.ts
@@ -123,6 +123,7 @@ export type Database = {
           join_code: string | null
           name: string
           previous_event_id: string | null
+          cover_image_url: string | null
         }
         Insert: {
           admin_profile_id?: string | null
@@ -135,6 +136,7 @@ export type Database = {
           join_code?: string | null
           name: string
           previous_event_id?: string | null
+          cover_image_url?: string | null
         }
         Update: {
           admin_profile_id?: string | null
@@ -147,6 +149,7 @@ export type Database = {
           join_code?: string | null
           name?: string
           previous_event_id?: string | null
+          cover_image_url?: string | null
         }
         Relationships: [
           {
@@ -296,6 +299,7 @@ export type Database = {
           family_group: string | null
           id: string
           locale: string | null
+          avatar_url: string | null
         }
         Insert: {
           created_at?: string | null
@@ -304,6 +308,7 @@ export type Database = {
           family_group?: string | null
           id: string
           locale?: string | null
+          avatar_url?: string | null
         }
         Update: {
           created_at?: string | null
@@ -312,6 +317,7 @@ export type Database = {
           family_group?: string | null
           id?: string
           locale?: string | null
+          avatar_url?: string | null
         }
         Relationships: []
       }
@@ -406,6 +412,7 @@ export type Database = {
           notes: string | null
           owner_id: string | null
           title: string | null
+          cover_image_url: string | null
         }
         Insert: {
           created_at?: string | null
@@ -414,6 +421,7 @@ export type Database = {
           notes?: string | null
           owner_id?: string | null
           title?: string | null
+          cover_image_url?: string | null
         }
         Update: {
           created_at?: string | null
@@ -422,6 +430,7 @@ export type Database = {
           notes?: string | null
           owner_id?: string | null
           title?: string | null
+          cover_image_url?: string | null
         }
         Relationships: [
           {

--- a/src/lib/placeholder.ts
+++ b/src/lib/placeholder.ts
@@ -1,0 +1,3 @@
+export const AVATAR_PLACEHOLDER = "https://placehold.co/64x64?text=%F0%9F%91%A4";
+export const EVENT_PLACEHOLDER = "https://placehold.co/600x200?text=Evento";
+export const ITEM_PLACEHOLDER = "https://placehold.co/300x300?text=Idea";

--- a/src/lib/upload.ts
+++ b/src/lib/upload.ts
@@ -1,0 +1,40 @@
+import { supabase } from "@/integrations/supabase/client";
+
+interface UploadArgs {
+  bucket: string;
+  path: string;
+  file: File;
+}
+
+export async function uploadImage({ bucket, path, file }: UploadArgs): Promise<string> {
+  const { error } = await supabase.storage
+    .from(bucket)
+    .upload(path, file, { upsert: true, contentType: file.type });
+  if (error) throw error;
+  const { data } = supabase.storage.from(bucket).getPublicUrl(path);
+  return data.publicUrl;
+}
+
+interface ResizeOpts {
+  max?: number;
+  quality?: number;
+}
+
+export async function resizeToWebP(file: File, opts: ResizeOpts = {}): Promise<File> {
+  const { max = 1024, quality = 0.85 } = opts;
+  const bitmap = await createImageBitmap(file);
+  const scale = Math.min(1, max / Math.max(bitmap.width, bitmap.height));
+  const canvas = document.createElement("canvas");
+  canvas.width = Math.round(bitmap.width * scale);
+  canvas.height = Math.round(bitmap.height * scale);
+  const ctx = canvas.getContext("2d");
+  if (!ctx) throw new Error("Canvas not supported");
+  ctx.drawImage(bitmap, 0, 0, canvas.width, canvas.height);
+  const blob: Blob | null = await new Promise((resolve) =>
+    canvas.toBlob(resolve, "image/webp", quality)
+  );
+  if (!blob) throw new Error("Unable to convert image");
+  return new File([blob], file.name.replace(/\.[^.]+$/, ".webp"), {
+    type: "image/webp",
+  });
+}

--- a/src/pages/Profile.tsx
+++ b/src/pages/Profile.tsx
@@ -51,6 +51,7 @@ const Profile = () => {
       setAvatarUrl(url);
       setFile(null);
       toast.success("Profilo aggiornato");
+      window.location.href = "/";
     } catch (err) {
       console.error(err);
       toast.error("Errore durante l'aggiornamento");

--- a/src/pages/Profile.tsx
+++ b/src/pages/Profile.tsx
@@ -1,0 +1,98 @@
+import { useEffect, useState } from "react";
+import { supabase } from "@/integrations/supabase/client";
+import { useAuth } from "@/components/AuthProvider";
+import { Input } from "@/components/ui/input";
+import { Button } from "@/components/ui/button";
+import { uploadImage, resizeToWebP } from "@/lib/upload";
+import { AVATAR_PLACEHOLDER } from "@/lib/placeholder";
+import { toast } from "sonner";
+
+const Profile = () => {
+  const { user } = useAuth();
+  const [displayName, setDisplayName] = useState("");
+  const [locale, setLocale] = useState("it");
+  const [avatarUrl, setAvatarUrl] = useState<string | null>(null);
+  const [file, setFile] = useState<File | null>(null);
+
+  useEffect(() => {
+    async function load() {
+      if (!user) return;
+      const { data } = await supabase
+        .from("profiles")
+        .select("display_name, locale, avatar_url")
+        .eq("id", user.id)
+        .single();
+      if (data) {
+        setDisplayName(data.display_name ?? "");
+        setLocale(data.locale ?? "it");
+        setAvatarUrl(data.avatar_url);
+      }
+    }
+    load();
+  }, [user]);
+
+  const handleSave = async () => {
+    if (!user) return;
+    let url = avatarUrl;
+    try {
+      if (file) {
+        const resized = await resizeToWebP(file, { max: 1024, quality: 0.85 });
+        url = await uploadImage({
+          bucket: "avatars",
+          path: `${user.id}/avatar.webp`,
+          file: resized,
+        });
+      }
+      const { error } = await supabase
+        .from("profiles")
+        .update({ display_name: displayName, locale, avatar_url: url })
+        .eq("id", user.id);
+      if (error) throw error;
+      setAvatarUrl(url);
+      setFile(null);
+      toast.success("Profilo aggiornato");
+    } catch (err) {
+      console.error(err);
+      toast.error("Errore durante l'aggiornamento");
+    }
+  };
+
+  if (!user) return null;
+
+  return (
+    <div className="max-w-xl mx-auto p-4 space-y-4">
+      <h1 className="text-2xl font-bold">Profilo</h1>
+      <div className="space-y-2">
+        <label className="text-sm">Email</label>
+        <Input value={user.email ?? ""} disabled />
+      </div>
+      <div className="space-y-2">
+        <label className="text-sm">Nome</label>
+        <Input
+          value={displayName}
+          onChange={(e) => setDisplayName(e.target.value)}
+        />
+      </div>
+      <div className="space-y-2">
+        <label className="text-sm">Locale</label>
+        <Input value={locale} onChange={(e) => setLocale(e.target.value)} />
+      </div>
+      <div className="space-y-2">
+        <label className="text-sm">Avatar</label>
+        <img
+          src={avatarUrl || AVATAR_PLACEHOLDER}
+          alt="avatar"
+          className="w-24 h-24 rounded-full object-cover"
+        />
+        <Input
+          type="file"
+          accept="image/*"
+          onChange={(e) => setFile(e.target.files?.[0] || null)}
+        />
+      </div>
+      <Button onClick={handleSave}>Salva</Button>
+    </div>
+  );
+};
+
+export default Profile;

--- a/supabase/migrations/20250908000000_profile_images.sql
+++ b/supabase/migrations/20250908000000_profile_images.sql
@@ -1,0 +1,28 @@
+-- Add avatar and cover image columns
+alter table public.profiles add column if not exists avatar_url text;
+
+alter table public.events add column if not exists cover_image_url text;
+
+alter table public.wishlists add column if not exists cover_image_url text;
+
+-- Ensure participants exist for all profiles
+insert into public.participants (profile_id)
+select p.id from public.profiles p
+where not exists (select 1 from public.participants pa where pa.profile_id = p.id);
+
+-- Ensure unique membership per event/participant
+alter table public.event_members
+  add constraint if not exists event_members_event_participant_key unique (event_id, participant_id);
+
+-- Ensure unique wishlist per event/owner
+alter table public.wishlists
+  add constraint if not exists wishlists_event_owner_key unique (event_id, owner_id);
+
+-- Create default wishlist for members without one
+insert into public.wishlists (event_id, owner_id, title)
+select em.event_id, em.participant_id, 'La mia lista'
+from public.event_members em
+where not exists (
+  select 1 from public.wishlists w
+  where w.event_id = em.event_id and w.owner_id = em.participant_id
+);


### PR DESCRIPTION
## Summary
- add /profile route to edit display name, locale, and avatar
- show profile avatar in navbar
- introduce image upload helpers and placeholders
- add database migration for image columns and uniqueness constraints

## Testing
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_68bd2091dae88323bd364e99321ae6b6