### PR TITLE
feat: add invite token flow and join route

### DIFF
--- a/api/join/create.ts
+++ b/api/join/create.ts
@@ -1,0 +1,68 @@
+import { createClient } from '@supabase/supabase-js';
+import crypto from 'crypto';
+
+const SUPABASE_URL = "https://eociecgrdwllggcohmko.supabase.co";
+const SUPABASE_SERVICE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY || process.env.SUPABASE_ANON_KEY || "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImVvY2llY2dyZHdsbGdnY29obWtvIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NTYzODc5ODcsImV4cCI6MjAzMTk2Mzk4N30.frsU_PCHKJdz8lFv2IXqOiUVFwk28hXbZGWZAoYFfBY";
+
+const supabase = createClient(SUPABASE_URL, SUPABASE_SERVICE_KEY);
+
+function generateToken(length = 22) {
+  const chars = '0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ';
+  const bytes = crypto.randomBytes(length);
+  let token = '';
+  for (let i = 0; i < length; i++) {
+    token += chars[bytes[i] % chars.length];
+  }
+  return token;
+}
+
+export default async function handler(req: any, res: any) {
+  if (req.method !== 'POST') {
+    return res.status(405).json({ error: 'Method not allowed' });
+  }
+
+  const authHeader = req.headers['authorization'];
+  if (!authHeader) {
+    return res.status(401).json({ error: 'Unauthorized' });
+  }
+  const accessToken = authHeader.replace('Bearer ', '');
+  const { data: { user }, error: userError } = await supabase.auth.getUser(accessToken);
+  if (userError || !user) {
+    return res.status(401).json({ error: 'Unauthorized' });
+  }
+
+  const { eventId, participantId, ttlDays = 30 } = req.body;
+  if (!eventId || !participantId) {
+    return res.status(400).json({ error: 'eventId and participantId required' });
+  }
+
+  const { data: event, error: eventError } = await supabase
+    .from('events')
+    .select('admin_profile_id')
+    .eq('id', eventId)
+    .single();
+  if (eventError || !event) {
+    return res.status(404).json({ error: 'Event not found' });
+  }
+  if (event.admin_profile_id !== user.id) {
+    return res.status(403).json({ error: 'Forbidden' });
+  }
+
+  const token = generateToken();
+  const expiresAt = new Date(Date.now() + ttlDays * 24 * 60 * 60 * 1000).toISOString();
+
+  const { error: insertError } = await supabase.from('join_tokens').insert({
+    event_id: eventId,
+    participant_id: participantId,
+    token,
+    expires_at: expiresAt,
+  });
+  if (insertError) {
+    return res.status(500).json({ error: insertError.message });
+  }
+
+  const origin = req.headers.origin || `${req.headers['x-forwarded-proto'] || 'https'}://${req.headers.host}`;
+  const url = `${origin}/join/${token}`;
+
+  return res.status(200).json({ token, url, expiresAt });
+}

--- a/src/components/AuthProvider.tsx
+++ b/src/components/AuthProvider.tsx
@@ -1,6 +1,7 @@
 import { createContext, useContext, useEffect, useState } from "react";
 import { User, Session } from "@supabase/supabase-js";
 import { supabase } from "@/integrations/supabase/client";
+import { useNavigate } from "react-router-dom";
 
 interface AuthContextType {
   user: User | null;
@@ -26,14 +27,23 @@ export const AuthProvider = ({ children }: { children: React.ReactNode }) => {
   const [user, setUser] = useState<User | null>(null);
   const [session, setSession] = useState<Session | null>(null);
   const [loading, setLoading] = useState(true);
+  const navigate = useNavigate();
 
   useEffect(() => {
     // Set up auth state listener
     const { data: { subscription } } = supabase.auth.onAuthStateChange(
-      (event, session) => {
+      async (event, session) => {
         setSession(session);
         setUser(session?.user ?? null);
         setLoading(false);
+
+        if (session?.user) {
+          const pending = localStorage.getItem("pendingJoinToken");
+          if (pending) {
+            localStorage.removeItem("pendingJoinToken");
+            navigate(`/join/${pending}`);
+          }
+        }
       }
     );
 
@@ -42,10 +52,18 @@ export const AuthProvider = ({ children }: { children: React.ReactNode }) => {
       setSession(session);
       setUser(session?.user ?? null);
       setLoading(false);
+
+      if (session?.user) {
+        const pending = localStorage.getItem("pendingJoinToken");
+        if (pending) {
+          localStorage.removeItem("pendingJoinToken");
+          navigate(`/join/${pending}`);
+        }
+      }
     });
 
     return () => subscription.unsubscribe();
-  }, []);
+  }, [navigate]);
 
   return (
     <AuthContext.Provider value={{ user, session, loading }}>

--- a/src/components/EventMembers.tsx
+++ b/src/components/EventMembers.tsx
@@ -7,10 +7,12 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Badge } from "@/components/ui/badge";
 import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle, DialogTrigger } from "@/components/ui/dialog";
-import { UserPlus, Trash2, Crown, User } from "lucide-react";
+import { UserPlus, Trash2, Crown, User, Copy, RefreshCw, MessageCircle } from "lucide-react";
 import { toast } from "sonner";
 import { getOrCreateParticipantId } from "@/lib/participants";
 import { debugLog, isDebug } from "@/lib/debug";
+import { StatusChip } from "@/components/StatusChip";
+import { copyToClipboard, shareViaWhatsApp } from "@/lib/whatsapp";
 
 interface EventMembersProps {
   eventId: string;
@@ -27,13 +29,14 @@ interface Member {
 }
 
 export const EventMembers = ({ eventId, userRole }: EventMembersProps) => {
-  const { user } = useAuth();
+  const { user, session } = useAuth();
   const [members, setMembers] = useState<Member[]>([]);
   const [isLoading, setIsLoading] = useState(true);
   const [isAddingMember, setIsAddingMember] = useState(false);
   const [newMemberName, setNewMemberName] = useState("");
   const [newMemberEmail, setNewMemberEmail] = useState("");
   const [diag, setDiag] = useState<any>({});
+  const [inviteLinks, setInviteLinks] = useState<Record<string, any>>({});
 
   useEffect(() => {
     fetchMembers();
@@ -98,35 +101,47 @@ export const EventMembers = ({ eventId, userRole }: EventMembersProps) => {
 
     setIsAddingMember(true);
     try {
-      // First get current user's participant ID to ensure they're admin
       const { data: participant } = await supabase
         .from('participants')
+        .insert({ profile_id: null })
         .select('id')
-        .eq('profile_id', user!.id)
         .single();
 
-      if (!participant) throw new Error("Participant not found");
+      if (!participant) throw new Error('Participant creation failed');
 
-      // Create anonymous member
-      const { error } = await supabase
+      const { data: memberRow, error: memberError } = await supabase
         .from('event_members')
         .insert({
           event_id: eventId,
-          participant_id: null, // Anonymous member
+          participant_id: participant.id,
           anonymous_name: newMemberName.trim(),
           anonymous_email: newMemberEmail.trim() || null,
-          role: 'member'
-        });
+          role: 'member',
+          status: 'invited'
+        })
+        .select('id, participant_id')
+        .single();
 
-      if (error) throw error;
+      if (memberError) throw memberError;
 
-      setNewMemberName("");
-      setNewMemberEmail("");
+      const inviteResp = await fetch('/api/join/create', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${session?.access_token}`,
+        },
+        body: JSON.stringify({ eventId, participantId: memberRow.participant_id }),
+      });
+      const invite = await inviteResp.json();
+      setInviteLinks((prev) => ({ ...prev, [memberRow.id]: invite }));
+
+      setNewMemberName('');
+      setNewMemberEmail('');
       await fetchMembers();
-      toast.success("Partecipante aggiunto!");
+      toast.success('Partecipante aggiunto!');
     } catch (error: unknown) {
       console.error('Error adding member:', error);
-      toast.error("Errore nell'aggiungere il partecipante");
+      toast.error('Errore nell\'aggiungere il partecipante');
     } finally {
       setIsAddingMember(false);
     }
@@ -257,11 +272,12 @@ export const EventMembers = ({ eventId, userRole }: EventMembersProps) => {
                   </div>
                 </div>
                 
-                <div className="flex items-center gap-2">
+                  <div className="flex items-center gap-2">
+                  <StatusChip status={member.status} />
                   {member.role === 'admin' && (
                     <Badge variant="secondary">Admin</Badge>
                   )}
-                  
+
                   {userRole === 'admin' && member.role !== 'admin' && (
                     <Button
                       variant="ghost"
@@ -271,11 +287,58 @@ export const EventMembers = ({ eventId, userRole }: EventMembersProps) => {
                       <Trash2 className="w-4 h-4 text-destructive" />
                     </Button>
                   )}
+                  </div>
                 </div>
-              </div>
-            </CardContent>
-          </Card>
-        ))}
+                {inviteLinks[member.id] && (
+                  <div className="mt-3 flex gap-2">
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      onClick={async () => {
+                        await copyToClipboard(inviteLinks[member.id].url);
+                        toast.success('Link copiato');
+                      }}
+                    >
+                      <Copy className="w-4 h-4 mr-2" />
+                      Copia Link
+                    </Button>
+                    <Button
+                      size="sm"
+                      className="bg-[#25D366] hover:bg-[#20BD5A] text-white"
+                      onClick={() => shareViaWhatsApp(inviteLinks[member.id].url)}
+                    >
+                      <MessageCircle className="w-4 h-4 mr-2" />
+                      WhatsApp
+                    </Button>
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      onClick={async () => {
+                        try {
+                          const resp = await fetch('/api/join/create', {
+                            method: 'POST',
+                            headers: {
+                              'Content-Type': 'application/json',
+                              Authorization: `Bearer ${session?.access_token}`,
+                            },
+                            body: JSON.stringify({ eventId, participantId: member.participant_id }),
+                          });
+                          const invite = await resp.json();
+                          setInviteLinks((prev) => ({ ...prev, [member.id]: invite }));
+                          toast.success('Link rigenerato');
+                        } catch {
+                          toast.error('Errore nel rigenerare il link');
+                        }
+                      }}
+                    >
+                      <RefreshCw className="w-4 h-4 mr-2" />
+                      Rigenera
+                    </Button>
+                  </div>
+                )}
+              </CardContent>
+            </Card>
+          ))}
       </div>
 
       {members.length === 0 && (

--- a/src/components/StatusChip.tsx
+++ b/src/components/StatusChip.tsx
@@ -1,0 +1,18 @@
+import { Badge } from "@/components/ui/badge";
+
+interface StatusChipProps {
+  status: string;
+}
+
+const variants: Record<string, string> = {
+  invited: "bg-yellow-100 text-yellow-800",
+  joined: "bg-green-100 text-green-800",
+  declined: "bg-red-100 text-red-800",
+  left: "bg-gray-100 text-gray-800",
+};
+
+export const StatusChip = ({ status }: StatusChipProps) => {
+  const className = variants[status] || "bg-muted text-muted-foreground";
+  const label = status ? status.charAt(0).toUpperCase() + status.slice(1) : "";
+  return <Badge className={className}>{label}</Badge>;
+};

--- a/src/pages/EventJoin.tsx
+++ b/src/pages/EventJoin.tsx
@@ -1,254 +1,93 @@
-import { useState, useEffect } from "react";
+import { useEffect, useState } from "react";
 import { useParams, useNavigate } from "react-router-dom";
 import { supabase } from "@/integrations/supabase/client";
-import { Button } from "@/components/ui/button";
-import { Input } from "@/components/ui/input";
-import { Label } from "@/components/ui/label";
+import { useAuth } from "@/components/AuthProvider";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import { Gift, Users, Calendar, Euro } from "lucide-react";
-import { toast } from "sonner";
-
-interface EventInfo {
-  id: string;
-  name: string;
-  budget: number | null;
-  date: string | null;
-}
+import { Button } from "@/components/ui/button";
 
 const EventJoin = () => {
   const { token } = useParams<{ token: string }>();
-  const [event, setEvent] = useState<EventInfo | null>(null);
-  const [name, setName] = useState("");
-  const [email, setEmail] = useState("");
-  const [loading, setLoading] = useState(true);
-  const [joining, setJoining] = useState(false);
+  const { user, loading } = useAuth();
   const navigate = useNavigate();
+  const [status, setStatus] = useState<"loading" | "invalid" | "expired" | "used">("loading");
 
   useEffect(() => {
-    if (token) {
-      validateTokenAndLoadEvent();
-    }
-  }, [token]);
+    if (!token || loading) return;
 
-  const validateTokenAndLoadEvent = async () => {
-    if (!token) return;
-    
-    setLoading(true);
-    try {
-      // Check if token is valid and get event info
-      const { data: joinToken, error: tokenError } = await supabase
+    const run = async () => {
+      const { data: jt, error } = await supabase
         .from("join_tokens")
-        .select(`
-          event_id,
-          expires_at,
-          used_at,
-          events (
-            id,
-            name,
-            budget,
-            date
-          )
-        `)
+        .select("event_id, participant_id, expires_at, used_at")
         .eq("token", token)
         .single();
 
-      if (tokenError || !joinToken) {
-        toast.error("Link non valido o scaduto");
-        navigate("/");
+      if (error || !jt) {
+        setStatus("invalid");
+        return;
+      }
+      if (jt.used_at) {
+        setStatus("used");
+        return;
+      }
+      if (new Date(jt.expires_at) < new Date()) {
+        setStatus("expired");
         return;
       }
 
-      if (joinToken.used_at) {
-        toast.error("Questo link è già stato utilizzato");
-        navigate("/");
+      if (!user) {
+        localStorage.setItem("pendingJoinToken", token);
+        navigate("/auth");
         return;
       }
 
-      if (new Date(joinToken.expires_at) < new Date()) {
-        toast.error("Questo link è scaduto");
-        navigate("/");
-        return;
-      }
-
-      // Store token in localStorage for later use
-      localStorage.setItem("joinToken", token);
-      setEvent(joinToken.events as EventInfo);
-
-    } catch (error: unknown) {
-      console.error("Error validating token:", error);
-      toast.error("Errore nel verificare il link");
-      navigate("/");
-    } finally {
-      setLoading(false);
-    }
-  };
-
-  const handleJoin = async (e: React.FormEvent) => {
-    e.preventDefault();
-    if (!name.trim() || !event) return;
-
-    setJoining(true);
-    try {
-      // Create anonymous participant
-      const { data: participant, error: participantError } = await supabase
+      await supabase
         .from("participants")
-        .insert({
-          profile_id: null // Anonymous participant
-        })
-        .select()
-        .single();
+        .update({ profile_id: user.id })
+        .eq("id", jt.participant_id)
+        .is("profile_id", null);
 
-      if (participantError) throw participantError;
-
-      // Add as event member with token info
-      const { error: memberError } = await supabase
+      await supabase
         .from("event_members")
-        .insert({
-          event_id: event.id,
-          participant_id: participant.id,
-          role: "member",
-          status: "joined",
-          join_token: token,
-          anonymous_name: name.trim(),
-          anonymous_email: email.trim() || null
-        });
+        .update({ status: "joined" })
+        .eq("event_id", jt.event_id)
+        .eq("participant_id", jt.participant_id);
 
-      if (memberError) throw memberError;
-
-      // Mark token as used
-      const { error: tokenError } = await supabase
+      await supabase
         .from("join_tokens")
-        .update({ 
-          used_at: new Date().toISOString(),
-          participant_id: participant.id
-        })
+        .update({ used_at: new Date().toISOString() })
         .eq("token", token);
 
-      if (tokenError) throw tokenError;
+      navigate(`/events/${jt.event_id}`);
+    };
 
-      // Store participant info in localStorage
-      localStorage.setItem("participantInfo", JSON.stringify({
-        participantId: participant.id,
-        eventId: event.id,
-        name,
-        email: email || null
-      }));
+    run();
+  }, [token, user, loading, navigate]);
 
-      toast.success(`Benvenuto/a ${name}! 🎉`);
-      navigate(`/events/${event.id}`);
-      
-    } catch (error: unknown) {
-      console.error("Error joining event:", error);
-      const description = error instanceof Error ? error.message : undefined;
-      toast.error("Errore nell'unirsi all'evento", {
-        description
-      });
-    } finally {
-      setJoining(false);
+  const renderMessage = () => {
+    switch (status) {
+      case "invalid":
+        return "Link non valido";
+      case "expired":
+        return "Link scaduto";
+      case "used":
+        return "Link già utilizzato";
+      default:
+        return "Verifica del link in corso...";
     }
   };
-
-  if (loading) {
-    return (
-      <div className="min-h-screen bg-gradient-hero flex items-center justify-center p-4">
-        <Card className="shadow-elegant border-0 bg-white/95 backdrop-blur-sm">
-          <CardContent className="p-8">
-            <div className="text-center space-y-4">
-              <div className="animate-spin w-8 h-8 border-2 border-primary border-t-transparent rounded-full mx-auto"></div>
-              <p>Verifica del link in corso...</p>
-            </div>
-          </CardContent>
-        </Card>
-      </div>
-    );
-  }
-
-  if (!event) {
-    return (
-      <div className="min-h-screen bg-gradient-hero flex items-center justify-center p-4">
-        <Card className="shadow-elegant border-0 bg-white/95 backdrop-blur-sm">
-          <CardContent className="p-8 text-center">
-            <h2 className="text-xl font-semibold mb-2">Link non trovato</h2>
-            <p className="text-muted-foreground">Questo link non è valido o è scaduto.</p>
-          </CardContent>
-        </Card>
-      </div>
-    );
-  }
 
   return (
     <div className="min-h-screen bg-gradient-hero flex items-center justify-center p-4">
-      <div className="w-full max-w-md">
-        <Card className="shadow-elegant border-0 bg-white/95 backdrop-blur-sm">
-          <CardHeader className="text-center space-y-4">
-            <div className="mx-auto w-16 h-16 bg-gradient-primary rounded-full flex items-center justify-center">
-              <Gift className="w-8 h-8 text-white" />
-            </div>
-            <div>
-              <CardTitle className="text-2xl font-bold bg-gradient-primary bg-clip-text text-transparent">
-                {event.name}
-              </CardTitle>
-              <div className="flex items-center justify-center gap-4 text-sm text-muted-foreground mt-3">
-                {event.budget && (
-                  <div className="flex items-center gap-1">
-                    <Euro className="w-4 h-4" />
-                    <span>{event.budget}€</span>
-                  </div>
-                )}
-                {event.date && (
-                  <div className="flex items-center gap-1">
-                    <Calendar className="w-4 h-4" />
-                    <span>{new Date(event.date).toLocaleDateString("it-IT")}</span>
-                  </div>
-                )}
-              </div>
-            </div>
+      <Card className="shadow-elegant border-0 bg-white/95 backdrop-blur-sm">
+        <CardContent className="p-8 text-center space-y-4">
+          <CardHeader className="p-0">
+            <CardTitle>{renderMessage()}</CardTitle>
           </CardHeader>
-          <CardContent>
-            <form onSubmit={handleJoin} className="space-y-4">
-              <div className="space-y-2">
-                <Label htmlFor="name">Il tuo nome</Label>
-                <Input
-                  id="name"
-                  placeholder="Come ti chiami?"
-                  value={name}
-                  onChange={(e) => setName(e.target.value)}
-                  required
-                />
-              </div>
-              
-              <div className="space-y-2">
-                <Label htmlFor="email">Email (opzionale)</Label>
-                <Input
-                  id="email"
-                  type="email"
-                  placeholder="la.tua@email.com"
-                  value={email}
-                  onChange={(e) => setEmail(e.target.value)}
-                />
-                <p className="text-xs text-muted-foreground">
-                  L'email è opzionale ma utile per ricevere aggiornamenti
-                </p>
-              </div>
-
-              <Button 
-                type="submit" 
-                className="w-full bg-gradient-primary hover:bg-primary-light transition-all duration-300 hover:shadow-glow"
-                disabled={joining}
-              >
-                {joining ? (
-                  "Unisciti..."
-                ) : (
-                  <>
-                    <Users className="w-4 h-4 mr-2" />
-                    Unisciti all'Evento
-                  </>
-                )}
-              </Button>
-            </form>
-          </CardContent>
-        </Card>
-      </div>
+          {(status === "invalid" || status === "expired" || status === "used") && (
+            <Button onClick={() => navigate("/")}>Torna alla home</Button>
+          )}
+        </CardContent>
+      </Card>
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- add serverless endpoint to mint participant join tokens
- show invite panel and status badges for event members
- handle invite link redemption and resume after login

## Testing
- `npm test`
- `npm run lint` *(fails: Unexpected any warnings/errors)*

------
https://chatgpt.com/codex/tasks/task_e_68bd83ae52488323a58057e6d04b5523