### PR TITLE
Add wishlist debug utilities and helpers

### DIFF
--- a/src/lib/dbDebug.ts
+++ b/src/lib/dbDebug.ts
@@ -1,0 +1,48 @@
+export function isWishlistDebug(): boolean {
+  try {
+    if (typeof window !== 'undefined') {
+      const qs = new URLSearchParams(window.location.search);
+      if (qs.get('debug') === 'wishlist') return true;
+    }
+  } catch {}
+  try {
+    if (typeof localStorage !== 'undefined') {
+      const ls = localStorage.getItem('DEBUG_WISHLIST');
+      if (ls === '1' || ls === 'true') return true;
+    }
+  } catch {}
+  return false;
+}
+
+export async function withDbDebug<T>(label: string, fn: () => Promise<T>): Promise<T> {
+  const start = performance.now();
+  try {
+    const result = await fn();
+    const ms = Math.round(performance.now() - start);
+    if (isWishlistDebug()) {
+      console.groupCollapsed(`[DB] ${label}`);
+      console.log({ ms, result });
+      console.groupEnd();
+    }
+    return result;
+  } catch (error: any) {
+    const ms = Math.round(performance.now() - start);
+    const info = {
+      label,
+      ms,
+      error: {
+        code: error?.code,
+        message: error?.message,
+        details: error?.details,
+        hint: error?.hint,
+      },
+    };
+    console.error(info);
+    if (isWishlistDebug()) {
+      console.groupCollapsed(`[DB ERR] ${label}`);
+      console.error(info);
+      console.groupEnd();
+    }
+    throw error;
+  }
+}

--- a/src/lib/wishlist.ts
+++ b/src/lib/wishlist.ts
@@ -1,0 +1,91 @@
+import { supabase } from "@/integrations/supabase/client";
+import { withDbDebug } from "./dbDebug";
+import { getOrCreateParticipantId } from "./participants";
+
+export type Wishlist = {
+  id: string;
+  event_id: string;
+  owner_id: string;
+  title: string | null;
+};
+
+export type WishlistItem = {
+  id: string;
+  wishlist_id: string;
+  title: string;
+  asin: string | null;
+  raw_url: string | null;
+  affiliate_url: string | null;
+  image_url: string | null;
+  price_snapshot: string | null;
+  created_at: string;
+};
+
+export async function getOrCreateDefaultWishlist(
+  eventId: string,
+  profileId: string,
+): Promise<Wishlist> {
+  return withDbDebug("wishlist:getOrCreateDefaultWishlist", async () => {
+    const ownerId = await getOrCreateParticipantId(profileId);
+    const existing = await supabase
+      .from("wishlists")
+      .select("id,event_id,owner_id,title")
+      .eq("event_id", eventId)
+      .eq("owner_id", ownerId)
+      .limit(1)
+      .maybeSingle();
+    if (existing.error) throw existing.error;
+    if (existing.data) return existing.data as Wishlist;
+
+    const inserted = await supabase
+      .from("wishlists")
+      .insert({ event_id: eventId, owner_id: ownerId, title: "La mia lista" })
+      .select("id,event_id,owner_id,title")
+      .single();
+    if (inserted.error) throw inserted.error;
+    return inserted.data as Wishlist;
+  });
+}
+
+export async function safeAddWishlistItem(params: {
+  eventId: string;
+  profileId: string;
+  item: {
+    title: string;
+    asin?: string | null;
+    raw_url?: string | null;
+    affiliate_url?: string | null;
+    image_url?: string | null;
+  };
+}): Promise<{ ok: true; wishlist_id: string } | { ok: false; error: string; code?: string }> {
+  return withDbDebug("wishlist:safeAddWishlistItem", async () => {
+    try {
+      const wishlist = await getOrCreateDefaultWishlist(
+        params.eventId,
+        params.profileId,
+      );
+      const { item } = params;
+      const insert = await supabase
+        .from("wishlist_items")
+        .insert({
+          wishlist_id: wishlist.id,
+          title: item.title,
+          asin: item.asin ?? null,
+          raw_url: item.raw_url ?? null,
+          affiliate_url: item.affiliate_url ?? null,
+          image_url: item.image_url ?? null,
+        })
+        .select("id")
+        .single();
+      if (insert.error) {
+        if (insert.error.code === "23505") {
+          return { ok: false, error: "Già in lista", code: insert.error.code };
+        }
+        return { ok: false, error: insert.error.message, code: insert.error.code };
+      }
+      return { ok: true, wishlist_id: wishlist.id };
+    } catch (e: any) {
+      return { ok: false, error: e?.message ?? "Errore", code: e?.code };
+    }
+  });
+}


### PR DESCRIPTION
## Summary
- add withDbDebug and isWishlistDebug utilities for Supabase calls
- centralize wishlist helpers with getOrCreateDefaultWishlist and safeAddWishlistItem

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bef688ddb88323a878c2e866e58bd5