### PR TITLE
Handle notification tab navigation

### DIFF
--- a/src/components/NotificationBell.tsx
+++ b/src/components/NotificationBell.tsx
@@ -40,8 +40,8 @@ export function NotificationBell() {
     const eventId = notification.event_id;
     
     if (notification.type === 'assignment' && eventId) {
-      // Navigate to event's draw tab
-      navigate(`/events/${eventId}?tab=sorteggio`);
+      // Navigate to event's assignment tab
+      navigate(`/events/${eventId}?tab=assegnazione`);
     } else if (notification.type === 'chat' && eventId) {
       // Navigate to event's chat tab
       if (notification.recipient_participant_id) {


### PR DESCRIPTION
## Summary
- update notification navigation to point assignment notifications to the assignment tab
- sync event detail tabs with URL parameters so tab selection and DM targets open correctly from links and notifications
- ensure chat deep links set the DM recipient while keeping tab query params up to date

## Testing
- npm run lint *(fails: existing lint errors in unrelated files)*


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693797c2ce008323bb56a4502baa0ebb)