### PR TITLE
Update contact information and jurisdiction clause in legal pages

### DIFF
--- a/src/pages/Cookies.tsx
+++ b/src/pages/Cookies.tsx
@@ -118,7 +118,7 @@ export default function Cookies() {
             </p>
             <ul className="list-disc pl-6 mb-4 space-y-2">
               <li>Attraverso le impostazioni del proprio account</li>
-              <li>Contattando il supporto: <strong>privacy@amicosegreto.it</strong></li>
+              <li>Contattando il supporto: <a href="mailto:privacy@amicosegreto.fun" className="text-primary underline">privacy@amicosegreto.fun</a></li>
               <li>Utilizzando le impostazioni del browser per eliminare i cookie esistenti</li>
             </ul>
           </div>
@@ -162,7 +162,7 @@ export default function Cookies() {
             Per domande riguardanti questa Cookie Policy, contattare:
           </p>
           <p>
-            <strong>Email:</strong> privacy@amicosegreto.it<br />
+            <strong>Email:</strong> <a href="mailto:privacy@amicosegreto.fun" className="text-primary underline">privacy@amicosegreto.fun</a><br />
             <strong>Oggetto:</strong> Cookie Policy - Richiesta informazioni
           </p>
         </section>

--- a/src/pages/Privacy.tsx
+++ b/src/pages/Privacy.tsx
@@ -20,8 +20,7 @@ export default function Privacy() {
           </p>
           <p className="mb-4">
             <strong>Contatti:</strong><br />
-            Email: help@amicosegreto.it<br />
-            Indirizzo: Viale Francesco del Greco 13, Vasto CH 66054
+            Email: <a href="mailto:privacy@amicosegreto.fun" className="text-primary underline">privacy@amicosegreto.fun</a>
           </p>
         </section>
 
@@ -119,7 +118,7 @@ export default function Privacy() {
             <li><strong>Revoca del consenso:</strong> revocare il consenso in qualsiasi momento</li>
           </ul>
           <p className="mb-4">
-            Per esercitare questi diritti, contattare: <strong>privacy@amicosegreto.it</strong>
+            Per esercitare questi diritti, contattare: <a href="mailto:privacy@amicosegreto.fun" className="text-primary underline">privacy@amicosegreto.fun</a>
           </p>
         </section>
 

--- a/src/pages/Terms.tsx
+++ b/src/pages/Terms.tsx
@@ -211,7 +211,8 @@ export default function Terms() {
           <h2 className="text-2xl font-semibold mb-4">11. Legge Applicabile e Foro Competente</h2>
           <p className="mb-4">
             I presenti Termini e Condizioni sono regolati dalla legge italiana. 
-            Per qualsiasi controversia sarà competente esclusivamente il Foro di [Città], Italia.
+            Per qualsiasi controversia sarà competente il Foro del luogo di residenza del consumatore,
+            ai sensi del Codice del Consumo (D.lgs. 206/2005).
           </p>
         </section>
 
@@ -240,8 +241,7 @@ export default function Terms() {
             Per domande riguardanti questi Termini e Condizioni, contattare:
           </p>
           <p>
-            <strong>Email:</strong> legal@amicosegreto.it<br />
-            <strong>Indirizzo:</strong> [Inserire indirizzo completo]<br />
+            <strong>Email:</strong> <a href="mailto:legal@amicosegreto.fun" className="text-primary underline">legal@amicosegreto.fun</a><br />
             <strong>Oggetto:</strong> Termini e Condizioni - Richiesta informazioni
           </p>
         </section>


### PR DESCRIPTION
## Summary
Updated contact information across Terms, Privacy, and Cookies pages to use the new domain and made the email addresses clickable links. Additionally, updated the jurisdiction clause in Terms to comply with Italian consumer protection law.

## Key Changes

- **Terms of Service (Terms.tsx)**
  - Updated jurisdiction clause to reference the consumer's place of residence per Italian Consumer Code (D.lgs. 206/2005) instead of a placeholder city
  - Changed legal contact email from `legal@amicosegreto.it` to `legal@amicosegreto.fun` and made it a clickable mailto link
  - Removed placeholder address field

- **Privacy Policy (Privacy.tsx)**
  - Updated contact email from `help@amicosegreto.it` to `privacy@amicosegreto.fun` with mailto link
  - Removed physical address (Viale Francesco del Greco 13, Vasto CH 66054)
  - Updated data rights contact email from `privacy@amicosegreto.it` to `privacy@amicosegreto.fun` with mailto link

- **Cookie Policy (Cookies.tsx)**
  - Updated all instances of `privacy@amicosegreto.it` to `privacy@amicosegreto.fun` with mailto links
  - Applied consistent styling with `text-primary underline` class to all email links

## Implementation Details
All email addresses are now implemented as proper mailto links using the `<a>` tag with `href="mailto:"` for improved user experience and accessibility.

https://claude.ai/code/session_01DRkEw3FkABKP7TNJG3QP4e